### PR TITLE
Remove duplicate help tag for g:lens#animate

### DIFF
--- a/doc/lens.txt
+++ b/doc/lens.txt
@@ -76,7 +76,6 @@ g:lens#disabled_filenames
 
              Default value is [].
                                                               *g:lens#animate*
-                                                              *g:lens#animate*
 g:lens#animate
              If value is 1 and animate.vim is installed, the window resize
              will be animated.


### PR DESCRIPTION
Could not use this extension using pkgs.vimUtils.buildVimPlugin in nix because of a duplicate tag error during the building of the help tags.