### PR TITLE
fix: don't minize windows on resize

### DIFF
--- a/plugin/lens.vim
+++ b/plugin/lens.vim
@@ -135,6 +135,11 @@ function! lens#run() abort
   else
     execute 'vertical resize ' . width
     execute 'resize ' . height
+    setlocal winfixheight
+    setlocal winfixwidth
+    wincmd =
+    setlocal nowinfixheight
+    setlocal nowinfixwidth
   endif
 endfunction
 


### PR DESCRIPTION
After window was resized use winfixwidth and winfixheight to fix window
size and run `wincmd =` to make all windows even (except windows with
fixed widths and heights). Unfix size afterwards.

Fixes #17 and probably fixes #19